### PR TITLE
ci(#2): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: lint · typecheck · test · build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## 개요
이슈 #2 (GitHub Actions 기본 워크플로 — lint + typecheck + unit test) 구현.

- 우선순위: P0
- 모드: CI/CD 하이브리드 (직접 구현)

Closes #2

## 변경 사항
- `.github/workflows/ci.yml` 신규
  - 트리거: `pull_request` (main 대상) + `push` (main)
  - Node 20.x + npm 캐시 활성화
  - 4개 Step: **lint → typecheck → test → build**
  - `timeout-minutes: 10`, `concurrency.cancel-in-progress` 활성
  - `permissions: contents: read` 최소권한

## 인수 기준 충족 여부
- [x] PR 생성 시 `ci` 잡이 자동 실행된다 (이 PR이 첫 검증 대상)
- [x] `lint`, `typecheck`, `test` 가 각각 별도 step (build 추가) 으로 실행되고 실패 시 PR 머지 불가능 표시
- [x] Node 20.x 사용, npm 캐시 활성화 (실행 시간 측정은 첫 런에서 확인)

## 로컬 검증
- ✅ YAML 구조 파싱 성공 (1 job `ci`, 2 triggers `pull_request`/`push`)
- ✅ 워크플로가 호출하는 npm scripts 4개 모두 `package.json` 에 존재 (lint/typecheck/test/build)
- ⚠️ actionlint·yamllint 로컬 미설치 → 원격 워크플로우 런으로 최종 검증 (STEP 7.5)

## 리뷰어가 봐야 할 곳
- `.github/workflows/ci.yml` — 워크플로 정의 전체
- 첫 PR 런 결과 (이 PR 자체가 첫 트리거)

## 다음 단계
머지 후 #3 (PR 보호 규칙 + 상태 배지 + CODEOWNERS) — 본 워크플로의 `ci` job을 required status check 로 등록.

---
🤖 Generated by `implement-top-issue` skill (v1.3, CI/CD 모드)