### PR TITLE
ci(#3): add CODEOWNERS, CI badge, and branch protection setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owner for everything in this repository.
+# Each line is a file pattern followed by one or more owners.
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+* @ischung

--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # todo-sdlc
 
-SDLC 실습용 Todo 애플리케이션 프로젝트.
+[![ci](https://github.com/ischung/todo-sdlc/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ischung/todo-sdlc/actions/workflows/ci.yml)
+
+대학생/취준생을 위한 **개인용 달력 Todo 앱** — SDLC 실습 프로젝트 (PRD → TechSpec → Vertical Slice + CI/CD-first).
+
+## 스택
+
+- **Frontend**: React 18 + TypeScript 5.4 + Vite 5
+- **Style**: TailwindCSS 3 (디자인 토큰: `brand` / `surface` / `ink`)
+- **Persistence**: Browser `localStorage` (백엔드 없음)
+- **Test**: Vitest + React Testing Library + Playwright (E2E)
+- **CI/CD**: GitHub Actions + GitHub Pages
+
+## 로컬 실행
+
+```bash
+npm install
+npm run dev          # 개발 서버 (http://localhost:5173)
+```
+
+## 스크립트
+
+| Script | 설명 |
+| :---- | :---- |
+| `npm run dev` | Vite 개발 서버 |
+| `npm run build` | 프로덕션 빌드 (TS 체크 후 `dist/` 출력) |
+| `npm run preview` | 빌드 산출물 미리보기 |
+| `npm run lint` | ESLint (warning 0 강제) |
+| `npm run typecheck` | TypeScript `--noEmit` |
+| `npm run test` | Vitest (단위·통합) |
+| `npm run format` | Prettier 일괄 포맷 |
+
+## 문서
+
+- [`prd.md`](./prd.md) — 제품 요구사항
+- [`techspec.md`](./techspec.md) — 기술 명세
+- [`issues-vertical.md`](./issues-vertical.md) — 이슈 분할 (Vertical Slice + CI/CD-first)
+
+## 기여 규칙
+
+- main 브랜치 직접 푸시 금지 → feature 브랜치 + PR
+- PR은 `ci` 워크플로(lint/typecheck/test/build)가 초록불이어야 머지 가능
+- 코드 소유자 자동 리뷰 요청: [`.github/CODEOWNERS`](./.github/CODEOWNERS)

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Apply branch protection rules to the `main` branch.
+#
+# Requirements:
+#   - gh CLI authenticated with a token that has `repo` admin scope
+#   - The `ci` status check (from .github/workflows/ci.yml) must have run at least once
+#
+# Rules enforced:
+#   - 1 review required (CODEOWNERS auto-requested)
+#   - `ci` status check is a required check (strict: branch must be up-to-date)
+#   - No force pushes, no branch deletion
+#   - Linear history enforced (squash/rebase only)
+#   - Conversation resolution required before merge
+#
+# Re-run is idempotent — GitHub overwrites the entire protection config on PUT.
+set -euo pipefail
+
+REPO="${REPO:-ischung/todo-sdlc}"
+BRANCH="${BRANCH:-main}"
+
+echo "Applying branch protection: $REPO @ $BRANCH"
+
+gh api \
+  --method PUT \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/$REPO/branches/$BRANCH/protection" \
+  --input - <<'JSON'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["lint · typecheck · test · build"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": true
+}
+JSON
+
+echo "✅ Branch protection applied."


### PR DESCRIPTION
## 개요
이슈 #3 (PR 보호 규칙 + 상태 배지 + CODEOWNERS) 구현.

- 우선순위: P0 · `mandatory-gate`
- 모드: CI/CD 하이브리드

Closes #3

## 변경 사항
- `.github/CODEOWNERS` — `* @ischung` (모든 경로 자동 리뷰어 지정)
- `README.md` — CI 상태 배지 + 스택/스크립트 표/기여 규칙 정리
- `scripts/setup-branch-protection.sh` — main 보호 규칙을 idempotent 하게 적용하는 헬퍼 (gh api PUT)

## 보호 규칙 사양
- ✅ 1 review required (CODEOWNERS 자동 요청)
- ✅ `lint · typecheck · test · build` 상태 체크 필수 + strict (브랜치 최신화 강제)
- ✅ main 직접 푸시 금지, force push 금지, 브랜치 삭제 금지
- ✅ Linear history (squash/rebase 머지만) + conversation resolution 강제

## 인수 기준 충족 여부
- [x] main 에 직접 push 시 거부된다 *(스크립트 실행 후 자동 적용)*
- [x] CI 실패 PR 은 머지 버튼이 비활성화된다 *(스크립트 실행 후)*
- [x] README 의 CI 배지가 main 의 최신 상태를 반영한다

## ⚠️ 사용자 직접 실행 필요
브랜치 보호 규칙은 저장소 governance 변경이라 본 자동화에서 직접 적용하지 않았습니다. 머지 후 다음 명령으로 적용해주세요:

\`\`\`bash
bash scripts/setup-branch-protection.sh
\`\`\`

## 로컬 검증
- ✅ CODEOWNERS 문법: GitHub 공식 패턴 준수 (`* @owner`)
- ✅ README 배지 URL: `https://github.com/ischung/todo-sdlc/actions/workflows/ci.yml/badge.svg?branch=main`
- ✅ 스크립트 shellcheck 친화적 (`set -euo pipefail`, here-doc JSON, idempotent PUT)

## 다음 단계
머지 후 #4 (GitHub Pages 스테이징 환경 준비) — Vite `base` 환경별 분기 + Pages 활성화.

---
🤖 Generated by `implement-top-issue` skill (v1.3, CI/CD 모드)