### PR TITLE
ci(#5): add main → gh-pages:/staging auto-deploy workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,71 @@
+name: deploy-staging
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - 'tailwind.config.js'
+      - 'postcss.config.js'
+      - 'tsconfig*.json'
+      - '.env.staging'
+      - '.github/workflows/deploy-staging.yml'
+  workflow_dispatch:
+
+# 동시 실행 시 가장 최신 push만 살리고 나머지는 즉시 취소.
+# 실패해도 in-progress 가 남지 않으므로 직전 gh-pages 상태가 유지됨 (AC-2).
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+permissions:
+  contents: write   # gh-pages 브랜치 push 용 (peaceiris/actions-gh-pages)
+
+jobs:
+  build-and-deploy:
+    name: build · deploy → gh-pages:/staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: staging
+      url: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/staging/
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (mode=staging)
+        run: npm run build -- --mode staging
+
+      - name: Deploy to gh-pages:/staging
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./dist
+          destination_dir: staging
+          keep_files: true   # /production 등 다른 폴더 보존
+          commit_message: 'chore(staging): deploy ${{ github.sha }}'
+          user_name: 'github-actions[bot]'
+          user_email: '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Print deploy URL
+        run: |
+          URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/staging/"
+          echo "::notice title=Staging deployed::$URL"
+          echo "🔗 Staging URL: $URL"
+          echo "STAGING_URL=$URL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 개요
이슈 #5 (main 머지 → 스테이징 자동 배포 워크플로) 구현.

- 우선순위: P0 · `profile:staging`
- 모드: CI/CD 하이브리드

Closes #5

## 변경 사항
`.github/workflows/deploy-staging.yml` 신규 — 단일 job 3단계 (install → build → deploy):

1. **트리거**: `main` push (소스/설정 변경 시) + `workflow_dispatch` 수동
2. **concurrency**: `cancel-in-progress: true` — 최신 push만 배포, 실패 시 직전 gh-pages 상태 유지
3. **environment: staging** — Actions UI 에 배포 URL 자동 표시
4. **빌드**: `npm run build -- --mode staging` (= base path `/todo-sdlc/staging/`)
5. **배포**: `peaceiris/actions-gh-pages@v4` 로 `dist/` → `gh-pages:/staging/` 푸시
   - `keep_files: true` → 형제 폴더 (`/`, `/production`) 보존
6. **URL 출력**: 마지막 step에서 `::notice` 로 Actions 로그에 배포 URL 출력

## 인수 기준 충족 여부
- [x] main 에 머지하면 5분 이내 스테이징 URL 이 갱신된다 *(머지 후 자동 트리거)*
- [x] 워크플로 실패 시 main 의 스테이징은 직전 버전을 유지한다 *(concurrency cancel + peaceiris의 idempotent commit)*
- [x] Actions 로그에 배포 URL 이 출력된다 *(`::notice` + STAGING_URL output)*

## 의존성
- 사용자가 머지 전/후로 다음 1회 실행 필요:
  ```bash
  bash scripts/setup-github-pages.sh   # gh-pages 브랜치 생성 + Pages 활성화
  ```
  (이미 #4 머지 후 실행했다면 생략)

## 검증
- ✅ YAML 구조 파싱 (1 job `build-and-deploy`, 6 steps, 2 triggers)
- ✅ CI 워크플로 (lint/typecheck/test/build) 영향 없음 — 별개 파일
- ⚠️ 실 배포 검증은 머지 직후 main push 로 자동 트리거됨

## 다음 단계
머지 후 #6 (배포 후 Playwright smoke test 자동 수행) — 본 워크플로 마지막에 smoke job 추가.

---
🤖 Generated by `implement-top-issue` skill (v1.3, CI/CD 모드)