### PR TITLE
ci(#6): add Playwright smoke test after staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,6 +14,8 @@ on:
       - 'postcss.config.js'
       - 'tsconfig*.json'
       - '.env.staging'
+      - 'playwright.config.ts'
+      - 'tests/smoke/**'
       - '.github/workflows/deploy-staging.yml'
   workflow_dispatch:
 
@@ -64,8 +66,59 @@ jobs:
           user_email: '41898282+github-actions[bot]@users.noreply.github.com'
 
       - name: Print deploy URL
+        id: url
         run: |
           URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/staging/"
           echo "::notice title=Staging deployed::$URL"
           echo "🔗 Staging URL: $URL"
-          echo "STAGING_URL=$URL" >> "$GITHUB_OUTPUT"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+    outputs:
+      staging_url: ${{ steps.url.outputs.url }}
+
+  smoke:
+    # AC-1: 스테이징 배포 직후 Playwright smoke 가 자동 실행된다 (needs로 직렬화)
+    # AC-2: smoke 실패 시 워크플로우가 빨간불이 된다 (별도 job + needs)
+    # AC-3: HTML 리포트가 artifact 로 업로드된다 (if: always)
+    name: playwright smoke (staging)
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SMOKE_BASE_URL: ${{ needs.build-and-deploy.outputs.staging_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for Pages propagation (≤ 2 min)
+        run: |
+          for i in $(seq 1 24); do
+            CODE=$(curl -sS -o /dev/null -w "%{http_code}" "$SMOKE_BASE_URL" || true)
+            echo "  attempt $i: HTTP $CODE"
+            [ "$CODE" = "200" ] && exit 0
+            sleep 5
+          done
+          echo "::warning title=Pages not 200::$SMOKE_BASE_URL"
+
+      - name: Run smoke tests against $SMOKE_BASE_URL
+        run: npx playwright test --reporter=list,html
+
+      - name: Upload Playwright HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,8 @@ coverage/
 *.d.ts
 !src/**/*.d.ts
 vite.config.js
+
+# Playwright
+playwright-report/
+test-results/
+playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.3.1",
         "@types/react": "^18.3.3",
@@ -1141,6 +1142,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5108,6 +5125,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\"",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:smoke": "playwright test"
   },
   "dependencies": {
     "date-fns": "^3.6.0",
@@ -23,6 +24,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.1",
     "@types/react": "^18.3.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const PREVIEW_URL = `http://127.0.0.1:${PORT}/todo-sdlc/staging/`;
+
+/**
+ * SMOKE_BASE_URL: 외부 URL 직접 검증용 (CI에서 배포된 staging URL 사용).
+ * 미설정 시 로컬 vite preview (--mode staging) 를 띄워 검증한다.
+ */
+const externalBase = process.env.SMOKE_BASE_URL?.replace(/\/?$/, '/');
+
+export default defineConfig({
+  testDir: './tests/smoke',
+  timeout: 30_000,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
+  use: {
+    baseURL: externalBase ?? PREVIEW_URL,
+    trace: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: externalBase
+    ? undefined
+    : {
+        command: `npm run build:staging && npx vite preview --mode staging --port ${PORT} --strictPort`,
+        url: PREVIEW_URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('staging smoke', () => {
+  test('홈 화면이 200 + 핵심 H1 + env 라벨 노출', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.status(), 'home should respond 200').toBe(200);
+
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(/Hello, Calendar Todo/i);
+    await expect(page.getByTestId('app-env')).toHaveText(/env: \w+/);
+  });
+
+  test('정적 자산이 깨지지 않고 로드된다', async ({ page }) => {
+    const failed: string[] = [];
+    page.on('requestfailed', (req) => failed.push(`${req.url()} ${req.failure()?.errorText ?? ''}`));
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    expect(failed, `failed requests:\n${failed.join('\n')}`).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,8 @@ export default defineConfig(({ mode }) => {
       environment: 'jsdom',
       setupFiles: ['./src/test/setup.ts'],
       css: true,
+      include: ['src/**/*.{test,spec}.{ts,tsx}'],
+      exclude: ['node_modules', 'dist', 'tests/**', 'playwright-report/**'],
     },
   };
 });


### PR DESCRIPTION
## 개요
이슈 #6 (배포 후 Playwright smoke test 자동 수행) 구현.

- 우선순위: P0 · `mandatory-gate` · `profile:staging`
- 모드: CI/CD 하이브리드

Closes #6

## 변경 사항

### 신규 파일
- `playwright.config.ts` — chromium only, CI에서 retries=2, HTML 리포트
  - `SMOKE_BASE_URL` 환경변수로 외부 URL 직접 검증, 미설정 시 `vite preview --mode staging` 로 로컬 검증
- `tests/smoke/home.spec.ts` — 2 spec
  1. 홈이 HTTP 200 + H1 "Hello, Calendar Todo" + `data-testid="app-env"` 노출
  2. 페이지 로드 중 정적 자산 요청 실패 0건

### 워크플로 변경
`.github/workflows/deploy-staging.yml`:
- `build-and-deploy.outputs.staging_url` 노출
- 신규 `smoke` job (`needs: build-and-deploy`)
  - Pages 전파 대기 (HTTP 200 폴링, 최대 2분)
  - `npx playwright test` (chromium)
  - HTML 리포트 artifact 업로드 (`if: always`, retention 14일)
- paths 필터에 `playwright.config.ts`, `tests/smoke/**` 추가

### 인프라 정리
- `vitest.exclude` 에 `tests/**` 추가 (Playwright 스펙 픽업 방지)
- `package.json` `test:smoke` 스크립트
- `.gitignore` `playwright-report/`, `test-results/`, `playwright/.cache/`

## 인수 기준 충족 여부
- [x] 스테이징 배포 직후 Playwright smoke 가 자동 실행된다 *(needs 로 build-and-deploy → smoke 직렬)*
- [x] smoke 실패 시 워크플로우가 빨간불이 된다 *(needs 직렬 + 별도 job 실패)*
- [x] HTML 리포트가 artifact 로 업로드된다 *(`upload-artifact@v4` + `if: always`)*

## 로컬 검증
- ✅ typecheck/lint/test (3/3 vitest)/build 모두 통과
- ✅ vitest 가 Playwright 스펙을 더 이상 픽업하지 않음 (include/exclude 분리)

## 다음 단계
머지 후 #7 (빈 월간 달력 그리드 + 오늘 날짜 강조) — 첫 Walking Skeleton 슬라이스로 진입.

---
🤖 Generated by `implement-top-issue` skill (v1.3, CI/CD 모드)