### PR TITLE
feat(#8): TodoRepository (localStorage) + load/save 인터페이스

### DIFF
--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,43 @@
+/** ISO 날짜 문자열 (YYYY-MM-DD). 시각 정보는 포함하지 않는다. */
+export type DateKey = string;
+
+export interface Todo {
+  /** 안정 식별자 (crypto.randomUUID) */
+  id: string;
+  /** 소속 날짜 (YYYY-MM-DD) */
+  date: DateKey;
+  /** 1~100자, trim 후 비어있지 않음 */
+  title: string;
+  /** 완료 여부 */
+  done: boolean;
+  /** 생성 시각 (ISO 8601) */
+  createdAt: string;
+  /** 마지막 변경 시각 */
+  updatedAt: string;
+}
+
+/** localStorage 에 저장되는 루트 스키마 */
+export interface PersistRoot {
+  /** 스키마 버전. 마이그레이션 분기 키 */
+  schemaVersion: 1;
+  /** date(YYYY-MM-DD) → Todo[] (조회 O(1), 저장 단순) */
+  todosByDate: Record<DateKey, Todo[]>;
+}
+
+/** 표준 결과 타입 — TechSpec §5-1 */
+export type Result<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: ErrorCode; message: string } };
+
+export type ErrorCode =
+  | 'VALIDATION_EMPTY_TITLE'
+  | 'VALIDATION_TITLE_TOO_LONG'
+  | 'STORAGE_QUOTA_EXCEEDED'
+  | 'STORAGE_PARSE_ERROR'
+  | 'STORAGE_UNAVAILABLE'
+  | 'NOT_FOUND';
+
+export const EMPTY_ROOT: PersistRoot = Object.freeze({
+  schemaVersion: 1,
+  todosByDate: {},
+}) as PersistRoot;

--- a/src/infra/TodoRepository.test.ts
+++ b/src/infra/TodoRepository.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  BACKUP_KEY,
+  STORAGE_KEY,
+  TodoRepository,
+  detectBrowserStorage,
+  type StorageLike,
+} from './TodoRepository';
+import type { PersistRoot, Todo } from '../domain/types';
+
+class MemoryStorage implements StorageLike {
+  private map = new Map<string, string>();
+  /** 다음 setItem 1회를 quota 에러로 던진다 (모의용) */
+  forceQuota = false;
+
+  getItem(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    if (this.forceQuota) {
+      this.forceQuota = false;
+      const err = new DOMException('over quota', 'QuotaExceededError');
+      throw err;
+    }
+    this.map.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  has(key: string): boolean {
+    return this.map.has(key);
+  }
+  raw(key: string): string | null {
+    return this.getItem(key);
+  }
+}
+
+const sampleTodo: Todo = {
+  id: '11111111-1111-1111-1111-111111111111',
+  date: '2026-04-27',
+  title: 'PRD 정리',
+  done: false,
+  createdAt: '2026-04-27T08:00:00.000Z',
+  updatedAt: '2026-04-27T08:00:00.000Z',
+};
+
+const sampleRoot: PersistRoot = {
+  schemaVersion: 1,
+  todosByDate: { '2026-04-27': [sampleTodo] },
+};
+
+describe('TodoRepository', () => {
+  let storage: MemoryStorage;
+  let repo: TodoRepository;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    repo = new TodoRepository(storage);
+  });
+
+  it('AC-1: load() returns empty tree for fresh storage', () => {
+    const r = repo.load();
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.data).toEqual({ schemaVersion: 1, todosByDate: {} });
+    }
+  });
+
+  it('AC-2: corrupted JSON is backed up and load() returns empty tree', () => {
+    storage.setItem(STORAGE_KEY, '{ this is not json');
+    const r = repo.load();
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data.todosByDate).toEqual({});
+    expect(storage.raw(BACKUP_KEY)).toBe('{ this is not json');
+    expect(storage.has(STORAGE_KEY)).toBe(false);
+  });
+
+  it('AC-2b: schema-mismatched JSON is also treated as corrupted', () => {
+    storage.setItem(STORAGE_KEY, JSON.stringify({ schemaVersion: 99, todosByDate: {} }));
+    const r = repo.load();
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.data).toEqual({ schemaVersion: 1, todosByDate: {} });
+    expect(storage.raw(BACKUP_KEY)).toMatch(/"schemaVersion":99/);
+  });
+
+  it('AC-3: save() then load() round-trips identical tree', () => {
+    const saved = repo.save(sampleRoot);
+    expect(saved.ok).toBe(true);
+    const loaded = repo.load();
+    expect(loaded.ok).toBe(true);
+    if (loaded.ok) expect(loaded.data).toEqual(sampleRoot);
+  });
+
+  it('save() returns STORAGE_QUOTA_EXCEEDED on quota violation', () => {
+    storage.forceQuota = true;
+    const r = repo.save(sampleRoot);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('STORAGE_QUOTA_EXCEEDED');
+  });
+
+  it('returns STORAGE_UNAVAILABLE when storage is null (private mode)', () => {
+    const headless = new TodoRepository(null);
+    const r = headless.load();
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error.code).toBe('STORAGE_UNAVAILABLE');
+    const s = headless.save(sampleRoot);
+    expect(s.ok).toBe(false);
+    if (!s.ok) expect(s.error.code).toBe('STORAGE_UNAVAILABLE');
+  });
+
+  it('detectBrowserStorage returns null when probe.setItem throws (private mode 시뮬)', () => {
+    const broken: Storage = {
+      length: 0,
+      clear: () => undefined,
+      getItem: () => null,
+      key: () => null,
+      removeItem: () => undefined,
+      setItem: () => {
+        throw new DOMException('blocked', 'SecurityError');
+      },
+    };
+    const original = window.localStorage;
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: broken });
+    try {
+      expect(detectBrowserStorage()).toBeNull();
+    } finally {
+      Object.defineProperty(window, 'localStorage', { configurable: true, value: original });
+    }
+  });
+
+  it('detectBrowserStorage returns the working storage when probe succeeds', () => {
+    const memory = new MemoryStorage();
+    const proxy: Storage = {
+      length: 0,
+      clear: () => undefined,
+      getItem: (k) => memory.getItem(k),
+      key: () => null,
+      removeItem: (k) => memory.removeItem(k),
+      setItem: (k, v) => memory.setItem(k, v),
+    };
+    const original = window.localStorage;
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: proxy });
+    try {
+      const detected = detectBrowserStorage();
+      expect(detected).toBe(proxy);
+    } finally {
+      Object.defineProperty(window, 'localStorage', { configurable: true, value: original });
+    }
+  });
+});

--- a/src/infra/TodoRepository.ts
+++ b/src/infra/TodoRepository.ts
@@ -1,0 +1,114 @@
+import type { PersistRoot, Result } from '../domain/types';
+
+export const STORAGE_KEY = 'todo-sdlc/v1';
+export const BACKUP_KEY = 'todo-sdlc/v1.bak';
+
+export interface StorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * 영속 저장 격리 계층 (TechSpec §2-1).
+ *
+ * - 단일 키 `todo-sdlc/v1` 에 PersistRoot 트리 전체를 직렬화
+ * - JSON 파싱 실패 시 원본을 `todo-sdlc/v1.bak` 으로 백업하고 빈 트리 반환
+ * - QuotaExceededError 는 STORAGE_QUOTA_EXCEEDED 결과로 변환
+ * - localStorage 자체가 비활성(시크릿 모드 등)이면 STORAGE_UNAVAILABLE
+ */
+export class TodoRepository {
+  constructor(private readonly storage: StorageLike | null) {}
+
+  load(): Result<PersistRoot> {
+    if (!this.storage) {
+      return { ok: false, error: { code: 'STORAGE_UNAVAILABLE', message: '저장소가 비활성화되었어요.' } };
+    }
+
+    const raw = this.storage.getItem(STORAGE_KEY);
+    if (raw === null || raw === '') {
+      return { ok: true, data: cloneEmpty() };
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      if (!isValidPersistRoot(parsed)) {
+        this.backupCorrupted(raw);
+        return { ok: true, data: cloneEmpty() };
+      }
+      return { ok: true, data: parsed };
+    } catch {
+      this.backupCorrupted(raw);
+      return { ok: true, data: cloneEmpty() };
+    }
+  }
+
+  save(root: PersistRoot): Result<void> {
+    if (!this.storage) {
+      return { ok: false, error: { code: 'STORAGE_UNAVAILABLE', message: '저장소가 비활성화되었어요.' } };
+    }
+
+    try {
+      this.storage.setItem(STORAGE_KEY, JSON.stringify(root));
+      return { ok: true, data: undefined };
+    } catch (err) {
+      if (isQuotaExceeded(err)) {
+        return {
+          ok: false,
+          error: {
+            code: 'STORAGE_QUOTA_EXCEEDED',
+            message: '저장 공간이 가득 찼어요. 오래된 항목을 정리해주세요.',
+          },
+        };
+      }
+      throw err;
+    }
+  }
+
+  private backupCorrupted(raw: string): void {
+    try {
+      this.storage?.setItem(BACKUP_KEY, raw);
+      this.storage?.removeItem(STORAGE_KEY);
+    } catch {
+      // 백업 실패는 치명적이지 않음 — 빈 트리로 계속
+    }
+  }
+}
+
+function cloneEmpty(): PersistRoot {
+  return { schemaVersion: 1, todosByDate: {} };
+}
+
+function isValidPersistRoot(value: unknown): value is PersistRoot {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Partial<PersistRoot>;
+  if (v.schemaVersion !== 1) return false;
+  if (typeof v.todosByDate !== 'object' || v.todosByDate === null) return false;
+  return true;
+}
+
+function isQuotaExceeded(err: unknown): boolean {
+  // 브라우저/jsdom 별 시그널: DOMException name 또는 legacy code
+  // (DOMException 이 Error 를 상속하지 않는 환경도 있어 instanceof 검사를 피한다)
+  if (typeof err !== 'object' || err === null) return false;
+  const e = err as { name?: string; code?: number };
+  return (
+    e.name === 'QuotaExceededError' ||
+    e.name === 'NS_ERROR_DOM_QUOTA_REACHED' ||
+    e.code === 22 ||
+    e.code === 1014
+  );
+}
+
+/** 브라우저의 window.localStorage 를 안전하게 가져오는 팩토리. SSR/시크릿 모드 가드. */
+export function detectBrowserStorage(): StorageLike | null {
+  try {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
+    const probeKey = '__todo-sdlc-probe__';
+    window.localStorage.setItem(probeKey, '1');
+    window.localStorage.removeItem(probeKey);
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## 개요
이슈 #8 (TodoRepository localStorage + load/save 인터페이스 — Walking Skeleton 두 번째 슬라이스) 구현.

- 우선순위: P0
- 모드: 일반

Closes #8

## 변경 사항

### 도메인 타입 — `src/domain/types.ts`
- `Todo`, `PersistRoot`, `DateKey`, `Result<T>`, `ErrorCode`
- `EMPTY_ROOT` 불변 상수 (TechSpec §4-1 일치)

### Repository — `src/infra/TodoRepository.ts`
- 단일 키 `todo-sdlc/v1` (TechSpec §4-3) 에 트리 전체 직렬화
- `load()`:
  - 빈 저장소 → 빈 트리 반환 (성공)
  - JSON 파싱 실패 또는 `schemaVersion ≠ 1` → 원본을 `todo-sdlc/v1.bak` 으로 백업 + 빈 트리 반환
- `save(root)`:
  - 정상: `Result<void>` ok
  - QuotaExceededError → `STORAGE_QUOTA_EXCEEDED` 코드로 변환
- `STORAGE_UNAVAILABLE` 코드: storage 가 null 일 때 (SSR/시크릿)
- `detectBrowserStorage()` 팩토리: 안전한 probe (set/remove) 후 사용 가능한 인스턴스만 반환

### 테스트 — `src/infra/TodoRepository.test.ts` (8건, AC 5건 요건 초과)
1. 빈 저장소에서 빈 트리 반환 *(AC-1)*
2. 손상 JSON → 백업 + 빈 트리 *(AC-2)*
3. schema mismatch → 백업 + 빈 트리 *(AC-2 보조)*
4. save → load 라운드트립 *(AC-3)*
5. quota 위반 → `STORAGE_QUOTA_EXCEEDED`
6. null storage → `STORAGE_UNAVAILABLE`
7. `detectBrowserStorage` probe 실패 시 null
8. `detectBrowserStorage` probe 성공 시 storage 반환

## 인수 기준 충족 여부
- [x] `load()` 가 빈 저장소에서 `{schemaVersion:1, todosByDate:{}}` 를 반환한다
- [x] 손상된 JSON 이 들어 있으면 백업 후 빈 트리를 반환한다
- [x] `save()` 후 `load()` 가 동일 트리를 복원한다
- [x] 단위 테스트 5개 이상, 모두 통과 (**8/8**)

## 로컬 검증
- ✅ typecheck / lint / test (**22/22 passed**, 신규 +8) / build

## 다음 단계
머지 후 #9 (TodoContext + useReducer 뼈대 — LOAD 액션) → Walking Skeleton 세 번째 슬라이스로 상태 관리 흐름 완성.

---
🤖 Generated by `implement-top-issue` skill (v1.3, 일반 모드)