### PR TITLE
ci(#16): add CodeQL SAST + npm audit security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,63 @@
+name: security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # 매주 일요일 03:00 KST (UTC 18:00 토요일)
+    - cron: '0 18 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write   # CodeQL 결과 업로드 (Security 탭 노출)
+  actions: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codeql:
+    name: CodeQL (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'
+
+  npm-audit:
+    name: npm audit (high · critical)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies (no scripts)
+        # ignore-scripts: postinstall 등 임의 스크립트가 의존성 스캐닝 단계에서 돌지 않도록 차단
+        run: npm ci --ignore-scripts
+
+      - name: Run npm audit (production)
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## 개요
이슈 #16 (CodeQL SAST + npm audit 의존성 스캔 워크플로) 구현.

- 우선순위: P0 · `mandatory-gate`
- 모드: CI/CD 하이브리드

Closes #16

## 변경 사항
`.github/workflows/security.yml` 신규 — 2 jobs 병렬:

### 1. `codeql`
- `github/codeql-action/init@v3` — 언어: `javascript-typescript`
- 쿼리 셋: `security-and-quality` (보안 + 품질)
- 결과는 GitHub Security 탭에 자동 노출

### 2. `npm-audit`
- `npm ci --ignore-scripts` — postinstall 등 임의 스크립트 차단
- `npm audit --omit=dev --audit-level=high` — production deps 의 high·critical 만 차단 (개발 의존성 노이즈 제외)

### 트리거
- `pull_request` (main 대상)
- `push` to main
- **`schedule: cron 0 18 * * 6`** — 매주 일요일 03:00 KST 정기 스캔
- `workflow_dispatch` 수동 실행

### 보안 가드
- `permissions: security-events: write` — CodeQL 결과 업로드 전용 최소권한
- `concurrency.cancel-in-progress` — PR 내 중복 런 절감

## 인수 기준 충족 여부
- [x] CodeQL 결과가 GitHub Security 탭에 노출된다 *(`category` 지정 + `analyze@v3`)*
- [x] npm audit 의 high/critical 발견 시 워크플로 빨간불 *(`--audit-level=high`)*
- [x] cron 트리거가 매주 자동 실행된다 *(`0 18 * * 6` UTC)*

## 로컬 검증
- ✅ YAML 구조 (2 jobs, 4 triggers, cron 정상)
- ✅ 로컬 `npm audit --omit=dev --audit-level=high` → **0 vulnerabilities**
- ✅ 기존 ci 워크플로우 (lint/typecheck/test/build) 영향 없음

## 다음 단계
머지 후 P1 의 #9 (TodoContext + useReducer 뼈대) 또는 잔여 P0 의 #17 (프로덕션 배포 파이프라인) 중 우선순위 캐스케이드 결과대로 진행.

---
🤖 Generated by `implement-top-issue` skill (v1.3, CI/CD 모드)