### PR TITLE
fix(smoke): use baseURL-relative path so 404 surfaces

### DIFF
--- a/tests/smoke/home.spec.ts
+++ b/tests/smoke/home.spec.ts
@@ -1,8 +1,13 @@
 import { expect, test } from '@playwright/test';
 
+// baseURL 자체(=staging 루트)로 이동해야 하므로 './' 사용.
+// Playwright 의 path 해석 규칙: '/' 로 시작하면 host-relative 가 되어
+// baseURL 의 path 부분(/todo-sdlc/staging/)을 무시하고 호스트 루트로 간다 → 404.
+const HOME = './';
+
 test.describe('staging smoke', () => {
   test('홈 화면이 200 + 핵심 H1 + env 라벨 노출', async ({ page }) => {
-    const response = await page.goto('/');
+    const response = await page.goto(HOME);
     expect(response?.status(), 'home should respond 200').toBe(200);
 
     await expect(page.getByRole('heading', { level: 1 })).toHaveText(/Hello, Calendar Todo/i);
@@ -12,7 +17,8 @@ test.describe('staging smoke', () => {
   test('정적 자산이 깨지지 않고 로드된다', async ({ page }) => {
     const failed: string[] = [];
     page.on('requestfailed', (req) => failed.push(`${req.url()} ${req.failure()?.errorText ?? ''}`));
-    await page.goto('/');
+    const response = await page.goto(HOME);
+    expect(response?.status(), 'home should respond 200').toBe(200);
     await page.waitForLoadState('networkidle');
     expect(failed, `failed requests:\n${failed.join('\n')}`).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- `page.goto('/')` 는 Playwright 규칙상 host-relative 라서 staging baseURL `https://ischung.github.io/todo-sdlc/staging/` 의 path 를 무시하고 호스트 루트로 가버림 → 404
- `./` 로 바꿔 baseURL 그대로 사용하도록 수정
- 두 번째 테스트도 상태코드 검증 추가 (이전엔 status 미검증으로 404 가 silently 통과)

## Why this matters
PR #28 머지 후 main 배포의 smoke job 이 빨갛게 떨어진 원인. 이 수정 없이는 staging URL 이 살아있어도 smoke 가 깨지고, 반대로 진짜 404 가 나도 두 번째 테스트는 통과해버림.

## Test plan
- [x] 로컬 `vite preview --mode staging` 띄우고 `SMOKE_BASE_URL=http://localhost:4173/todo-sdlc/staging/ npx playwright test` → 2 passed
- [ ] CI 의 deploy-staging → smoke job 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)