### PR TITLE
feat(#9): TodoContext + useReducer skeleton (LOAD)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { CalendarView } from './calendar/CalendarView';
+import { TodoProvider } from './state/TodoContext';
 
 declare const __APP_ENV__: string;
 
@@ -6,17 +7,19 @@ export default function App() {
   const appEnv = typeof __APP_ENV__ !== 'undefined' ? __APP_ENV__ : 'development';
 
   return (
-    <main className="min-h-screen bg-surface-subtle text-ink p-6 max-w-5xl mx-auto">
-      <header className="mb-6">
-        <h1 className="text-2xl font-semibold tracking-tight text-brand-700">
-          Hello, Calendar Todo
-        </h1>
-        <p className="mt-1 text-xs text-ink-faint" data-testid="app-env">
-          env: {appEnv}
-        </p>
-      </header>
+    <TodoProvider>
+      <main className="min-h-screen bg-surface-subtle text-ink p-6 max-w-5xl mx-auto">
+        <header className="mb-6">
+          <h1 className="text-2xl font-semibold tracking-tight text-brand-700">
+            Hello, Calendar Todo
+          </h1>
+          <p className="mt-1 text-xs text-ink-faint" data-testid="app-env">
+            env: {appEnv}
+          </p>
+        </header>
 
-      <CalendarView />
-    </main>
+        <CalendarView />
+      </main>
+    </TodoProvider>
   );
 }

--- a/src/state/TodoContext.test.tsx
+++ b/src/state/TodoContext.test.tsx
@@ -1,0 +1,79 @@
+import { render, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import type { ReactNode } from 'react';
+import { TodoProvider } from './TodoContext';
+import { useTodos } from './useTodos';
+import { STORAGE_KEY, type StorageLike } from '../infra/TodoRepository';
+import type { PersistRoot } from '../domain/types';
+
+function memoryStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+  };
+}
+
+const wrap =
+  (storage: StorageLike | null) =>
+  ({ children }: { children: ReactNode }) => <TodoProvider storage={storage}>{children}</TodoProvider>;
+
+describe('<TodoProvider />', () => {
+  it('useTodos 가 Provider 밖에서 호출되면 친절한 오류를 던진다', () => {
+    expect(() => renderHook(() => useTodos())).toThrow(/TodoProvider/);
+  });
+
+  it('진입 시 LOAD 가 1회 디스패치되어 loaded=true 가 된다', async () => {
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(memoryStorage()) });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+  });
+
+  it('listByDate 가 빈 저장소일 때 빈 배열을 반환한다', async () => {
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(memoryStorage()) });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+    expect(result.current.listByDate('2026-04-27')).toEqual([]);
+    expect(result.current.countByDate('2026-04-27')).toBe(0);
+  });
+
+  it('저장된 데이터가 있으면 listByDate 가 그 배열을 정확히 반환한다', async () => {
+    const seeded: PersistRoot = {
+      schemaVersion: 1,
+      todosByDate: {
+        '2026-04-27': [
+          {
+            id: 'a',
+            date: '2026-04-27',
+            title: '집중 시간 90분',
+            done: false,
+            createdAt: '2026-04-27T09:00:00.000Z',
+            updatedAt: '2026-04-27T09:00:00.000Z',
+          },
+        ],
+      },
+    };
+    const storage = memoryStorage({ [STORAGE_KEY]: JSON.stringify(seeded) });
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(storage) });
+
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+    expect(result.current.listByDate('2026-04-27')).toHaveLength(1);
+    expect(result.current.listByDate('2026-04-27')[0]?.title).toBe('집중 시간 90분');
+    expect(result.current.countByDate('2026-04-27')).toBe(1);
+    expect(result.current.listByDate('2026-04-28')).toEqual([]);
+  });
+
+  it('storage=null (시크릿 모드 등) 이어도 충돌 없이 빈 트리로 LOAD 된다', async () => {
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(null) });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+    expect(result.current.listByDate('2026-04-27')).toEqual([]);
+  });
+
+  it('Provider 가 자식 트리를 그대로 렌더링한다', () => {
+    const { getByText } = render(
+      <TodoProvider storage={memoryStorage()}>
+        <p>child</p>
+      </TodoProvider>,
+    );
+    expect(getByText('child')).toBeInTheDocument();
+  });
+});

--- a/src/state/TodoContext.tsx
+++ b/src/state/TodoContext.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, useReducer, type ReactNode } from 'react';
+import { TodoRepository, detectBrowserStorage, type StorageLike } from '../infra/TodoRepository';
+import { TodoContext, type TodoContextValue } from './todoContextValue';
+import {
+  initialTodosState,
+  selectCountByDate,
+  selectListByDate,
+  todosReducer,
+} from './todosReducer';
+
+export interface TodoProviderProps {
+  children: ReactNode;
+  /** 테스트용 저장소 주입. 미지정 시 window.localStorage 자동 감지. */
+  storage?: StorageLike | null;
+}
+
+export function TodoProvider({ children, storage }: TodoProviderProps) {
+  const repository = useMemo(
+    () => new TodoRepository(storage === undefined ? detectBrowserStorage() : storage),
+    [storage],
+  );
+  const [state, dispatch] = useReducer(todosReducer, initialTodosState);
+
+  useEffect(() => {
+    const result = repository.load();
+    if (result.ok) {
+      dispatch({ type: 'LOAD', payload: result.data });
+    } else {
+      dispatch({ type: 'LOAD', payload: { schemaVersion: 1, todosByDate: {} } });
+    }
+  }, [repository]);
+
+  const value = useMemo<TodoContextValue>(
+    () => ({
+      state,
+      listByDate: (date) => selectListByDate(state, date),
+      countByDate: (date) => selectCountByDate(state, date),
+    }),
+    [state],
+  );
+
+  return <TodoContext.Provider value={value}>{children}</TodoContext.Provider>;
+}

--- a/src/state/todoContextValue.ts
+++ b/src/state/todoContextValue.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import type { DateKey, Todo } from '../domain/types';
+import type { TodosState } from './todosReducer';
+
+export interface TodoContextValue {
+  state: TodosState;
+  listByDate: (date: DateKey) => Todo[];
+  countByDate: (date: DateKey) => number;
+}
+
+export const TodoContext = createContext<TodoContextValue | null>(null);

--- a/src/state/todosReducer.ts
+++ b/src/state/todosReducer.ts
@@ -1,0 +1,31 @@
+import type { PersistRoot, Todo, DateKey } from '../domain/types';
+
+export interface TodosState {
+  /** 진입 시 LOAD 디스패치 전까지는 false */
+  loaded: boolean;
+  root: PersistRoot;
+}
+
+export type TodosAction = { type: 'LOAD'; payload: PersistRoot };
+
+export const initialTodosState: TodosState = {
+  loaded: false,
+  root: { schemaVersion: 1, todosByDate: {} },
+};
+
+export function todosReducer(state: TodosState, action: TodosAction): TodosState {
+  switch (action.type) {
+    case 'LOAD':
+      return { loaded: true, root: action.payload };
+    default:
+      return state;
+  }
+}
+
+export function selectListByDate(state: TodosState, date: DateKey): Todo[] {
+  return state.root.todosByDate[date] ?? [];
+}
+
+export function selectCountByDate(state: TodosState, date: DateKey): number {
+  return selectListByDate(state, date).length;
+}

--- a/src/state/useTodos.ts
+++ b/src/state/useTodos.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { TodoContext, type TodoContextValue } from './todoContextValue';
+
+export function useTodos(): TodoContextValue {
+  const ctx = useContext(TodoContext);
+  if (!ctx) {
+    throw new Error('useTodos 는 <TodoProvider> 내부에서만 사용할 수 있어요.');
+  }
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- 모든 슬라이스가 공유할 상태 관리 뼈대를 만든다 (Provider → Hook → Reducer → Repository).
- LOAD 액션만 구현: 진입 시 1회 디스패치되어 저장된 트리를 화면 트리로 끌어올린다.
- `listByDate`, `countByDate` 셀렉터를 노출 — 이후 #10~#14 슬라이스가 그대로 소비.
- Hook(`useTodos`)을 별도 파일로 분리해 react-refresh 경고 제거.

## AC
- [x] App 이 TodoProvider 로 감싸져 있다
- [x] 진입 시 1회 LOAD 디스패치
- [x] listByDate('2026-04-27') 빈 배열 / 시드 데이터 둘 다 정확
- [x] 단위 테스트 통과 (RTL renderHook 으로 Provider 래핑)

## Test plan
- [x] `npm run lint` 0 warnings
- [x] `npm run typecheck` 통과
- [x] `npm test` 28 passed (5 files)
- [x] `npm run build` 통과

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)