### PR TITLE
feat(#11): Slice 2 — click date → add todo + persist

### DIFF
--- a/src/calendar/AddTodoFlow.test.tsx
+++ b/src/calendar/AddTodoFlow.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { CalendarView } from './CalendarView';
+import { TodoProvider } from '../state/TodoContext';
+import { STORAGE_KEY, type StorageLike } from '../infra/TodoRepository';
+
+function memoryStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+  };
+}
+
+describe('Add-todo flow (#11)', () => {
+  it('날짜 클릭 → 패널 열림 → Enter → 목록 갱신 + 입력창 비워짐 + 카운트 증가', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    const storage = memoryStorage();
+
+    render(
+      <TodoProvider storage={storage} generateId={() => 'id-1'} now={() => today}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    // 진입 LOAD 완료 기다림 (셀이 렌더 끝날 때까지)
+    const todayCell = await screen.findByLabelText(/2026-04-27, 오늘/);
+    await user.click(todayCell);
+
+    const panel = await screen.findByTestId('day-detail-panel');
+    const input = within(panel).getByTestId('todo-input') as HTMLInputElement;
+
+    await user.type(input, '집중 시간 90분{enter}');
+
+    await waitFor(() => {
+      expect(within(panel).getByTestId('todo-list')).toBeInTheDocument();
+    });
+    expect(within(panel).getAllByTestId('todo-item')).toHaveLength(1);
+    expect(within(panel).getByTestId('todo-item').textContent).toBe('집중 시간 90분');
+    expect(input.value).toBe('');
+    expect(input).toHaveFocus();
+
+    // localStorage 영속 확인 — 새로고침에도 살아남아야 한다
+    const persisted = storage.getItem(STORAGE_KEY);
+    expect(persisted).not.toBeNull();
+    expect(JSON.parse(persisted!).todosByDate['2026-04-27']).toHaveLength(1);
+  });
+
+  it('빈 입력은 차단되고 에러 메시지가 노출된다', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    render(
+      <TodoProvider storage={memoryStorage()}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+    await user.click(await screen.findByLabelText(/2026-04-27, 오늘/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    const addBtn = within(panel).getByTestId('todo-add');
+    await user.click(addBtn);
+    expect(within(panel).getByTestId('todo-input-error')).toBeInTheDocument();
+    expect(within(panel).queryByTestId('todo-list')).not.toBeInTheDocument();
+  });
+
+  it('입력 maxLength=100 으로 100자 초과 입력이 차단된다', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    render(
+      <TodoProvider storage={memoryStorage()}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+    await user.click(await screen.findByLabelText(/2026-04-27, 오늘/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    const input = within(panel).getByTestId('todo-input') as HTMLInputElement;
+    expect(input.maxLength).toBe(100);
+  });
+
+  it('초기 시드 데이터가 있을 때 셀에 카운트 배지가 표시된다', async () => {
+    const today = new Date(2026, 3, 27);
+    const seeded = {
+      schemaVersion: 1,
+      todosByDate: {
+        '2026-04-27': [
+          {
+            id: 'a',
+            date: '2026-04-27',
+            title: '운동',
+            done: false,
+            createdAt: today.toISOString(),
+            updatedAt: today.toISOString(),
+          },
+          {
+            id: 'b',
+            date: '2026-04-27',
+            title: '독서',
+            done: true,
+            createdAt: today.toISOString(),
+            updatedAt: today.toISOString(),
+          },
+        ],
+      },
+    };
+    const storage = memoryStorage({ [STORAGE_KEY]: JSON.stringify(seeded) });
+
+    render(
+      <TodoProvider storage={storage}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    const todayCell = await screen.findByLabelText(/2026-04-27.*할 일 2개/);
+    expect(within(todayCell).getByTestId('todo-count').textContent).toBe('2');
+  });
+});

--- a/src/calendar/CalendarView.test.tsx
+++ b/src/calendar/CalendarView.test.tsx
@@ -2,17 +2,36 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 import { CalendarView } from './CalendarView';
+import { TodoProvider } from '../state/TodoContext';
+import type { StorageLike } from '../infra/TodoRepository';
+
+function memStorage(): StorageLike {
+  const m = new Map<string, string>();
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => void m.set(k, v),
+    removeItem: (k) => void m.delete(k),
+  };
+}
+
+function renderCalendar(anchor: Date, today: Date) {
+  return render(
+    <TodoProvider storage={memStorage()}>
+      <CalendarView anchor={anchor} today={today} />
+    </TodoProvider>,
+  );
+}
 
 describe('<CalendarView />', () => {
   it('renders the month header', () => {
     const today = new Date(2026, 3, 27); // April 27, 2026
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('2026년 4월');
   });
 
   it('renders 7 columns × 6 weeks = 42 grid cells + 7 column headers', () => {
     const today = new Date(2026, 3, 27);
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
     const grid = screen.getByRole('grid');
     expect(within(grid).getAllByRole('gridcell')).toHaveLength(42);
     expect(within(grid).getAllByRole('columnheader')).toHaveLength(7);
@@ -20,7 +39,7 @@ describe('<CalendarView />', () => {
 
   it('highlights today with brand-700 + bold (AC-2)', () => {
     const today = new Date(2026, 3, 27);
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
     const todayCell = screen.getByLabelText(/2026-04-27, 오늘/);
     const dayLabel = todayCell.querySelector('span');
     expect(dayLabel?.className).toMatch(/text-brand-700/);
@@ -29,9 +48,7 @@ describe('<CalendarView />', () => {
   });
 
   it('does not highlight any cell when today is in another month', () => {
-    render(
-      <CalendarView anchor={new Date(2026, 5, 15)} today={new Date(2026, 3, 27)} />,
-    );
+    renderCalendar(new Date(2026, 5, 15), new Date(2026, 3, 27));
     const cells = screen.getAllByRole('gridcell');
     const highlighted = cells.filter((c) => c.getAttribute('aria-current') === 'date');
     expect(highlighted).toHaveLength(0);
@@ -40,7 +57,7 @@ describe('<CalendarView />', () => {
   it('다음 달 클릭 시 헤더와 셀이 갱신된다 (#10 AC-1)', async () => {
     const user = userEvent.setup();
     const today = new Date(2026, 3, 27);
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('2026년 4월');
 
     await user.click(screen.getByTestId('next-month'));
@@ -53,7 +70,7 @@ describe('<CalendarView />', () => {
   it('이전 달 → 오늘 버튼으로 현재 월 복귀 + 오늘 강조 (#10 AC-2)', async () => {
     const user = userEvent.setup();
     const today = new Date(2026, 3, 27);
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
 
     await user.click(screen.getByTestId('prev-month'));
     expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('2026년 3월');
@@ -71,7 +88,7 @@ describe('<CalendarView />', () => {
 
   it('marks out-of-month cells visually distinct', () => {
     const today = new Date(2026, 3, 27);
-    render(<CalendarView anchor={today} today={today} />);
+    renderCalendar(today, today);
     const outOfMonth = screen
       .getAllByRole('gridcell')
       .filter((c) => c.dataset.outOfMonth === 'true');

--- a/src/calendar/CalendarView.tsx
+++ b/src/calendar/CalendarView.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { addMonths, format, startOfMonth, subMonths } from 'date-fns';
+import type { DateKey } from '../domain/types';
+import { useTodos } from '../state/useTodos';
 import { buildMonthGrid, type CalendarCell } from './buildMonthGrid';
+import { DayDetailPanel } from './DayDetailPanel';
 
 const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -14,6 +17,7 @@ interface CalendarViewProps {
 export function CalendarView({ anchor, today }: CalendarViewProps) {
   const todayDate = today ?? new Date();
   const [anchorDate, setAnchorDate] = useState<Date>(() => startOfMonth(anchor ?? todayDate));
+  const [openDate, setOpenDate] = useState<DateKey | null>(null);
 
   const cells = buildMonthGrid(anchorDate, todayDate);
   const monthLabel = format(anchorDate, 'yyyy년 M월');
@@ -72,19 +76,23 @@ export function CalendarView({ anchor, today }: CalendarViewProps) {
         ))}
 
         {cells.map((cell) => (
-          <DateCell key={cell.key} cell={cell} />
+          <DateCell key={cell.key} cell={cell} onSelect={() => setOpenDate(cell.key)} />
         ))}
       </div>
+
+      {openDate ? <DayDetailPanel date={openDate} onClose={() => setOpenDate(null)} /> : null}
     </section>
   );
 }
 
 interface DateCellProps {
   cell: CalendarCell;
+  onSelect: () => void;
 }
 
-function DateCell({ cell }: DateCellProps) {
-  const base = 'bg-surface min-h-[5.5rem] p-2 text-left flex flex-col';
+function DateCell({ cell, onSelect }: DateCellProps) {
+  const { countByDate } = useTodos();
+  const count = countByDate(cell.key);
   const dayClass = cell.isToday
     ? 'text-sm font-bold text-brand-700'
     : cell.inCurrentMonth
@@ -92,16 +100,23 @@ function DateCell({ cell }: DateCellProps) {
       : 'text-sm text-ink-faint';
 
   return (
-    <div
+    <button
+      type="button"
       role="gridcell"
-      aria-label={`${cell.key}${cell.isToday ? ', 오늘' : ''}`}
+      onClick={onSelect}
+      aria-label={`${cell.key}${cell.isToday ? ', 오늘' : ''}${count > 0 ? `, 할 일 ${count}개` : ''}`}
       aria-current={cell.isToday ? 'date' : undefined}
       data-date={cell.key}
       data-today={cell.isToday || undefined}
       data-out-of-month={!cell.inCurrentMonth || undefined}
-      className={base}
+      className="bg-surface min-h-[5.5rem] p-2 text-left flex flex-col hover:bg-surface-subtle focus:outline-none focus:ring-2 focus:ring-brand-500"
     >
       <span className={dayClass}>{cell.day}</span>
-    </div>
+      {count > 0 ? (
+        <span data-testid="todo-count" className="mt-auto text-xs text-ink-muted">
+          {count}
+        </span>
+      ) : null}
+    </button>
   );
 }

--- a/src/calendar/DayDetailPanel.tsx
+++ b/src/calendar/DayDetailPanel.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+import type { DateKey } from '../domain/types';
+import { TodoInputForm } from './TodoInputForm';
+import { TodoList } from './TodoList';
+
+interface DayDetailPanelProps {
+  date: DateKey;
+  onClose: () => void;
+}
+
+export function DayDetailPanel({ date, onClose }: DayDetailPanelProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${date} 할 일 패널`}
+      data-testid="day-detail-panel"
+      className="fixed inset-0 z-40 flex items-end justify-center bg-ink/30 sm:items-center"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <section className="w-full max-w-md rounded-t-card bg-surface-subtle p-4 shadow-card sm:rounded-card">
+        <header className="mb-3 flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-ink">{date}</h3>
+          <button
+            ref={closeRef}
+            type="button"
+            onClick={onClose}
+            aria-label="닫기"
+            data-testid="day-detail-close"
+            className="rounded-md px-2 py-1 text-sm text-ink-muted hover:bg-surface-muted"
+          >
+            ✕
+          </button>
+        </header>
+        <div className="flex flex-col gap-3">
+          <TodoInputForm date={date} />
+          <TodoList date={date} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/calendar/TodoInputForm.tsx
+++ b/src/calendar/TodoInputForm.tsx
@@ -1,0 +1,64 @@
+import { useRef, useState, type FormEvent } from 'react';
+import type { DateKey } from '../domain/types';
+import { useTodos } from '../state/useTodos';
+
+const TITLE_MAX = 100;
+
+interface TodoInputFormProps {
+  date: DateKey;
+}
+
+export function TodoInputForm({ date }: TodoInputFormProps) {
+  const { addTodo } = useTodos();
+  const [value, setValue] = useState('');
+  const [shake, setShake] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const result = addTodo({ date, title: value });
+    if (!result.ok) {
+      setError(result.error.message);
+      setShake(true);
+      window.setTimeout(() => setShake(false), 320);
+      return;
+    }
+    setValue('');
+    setError(null);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} aria-label="할 일 추가" className="flex flex-col gap-1">
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          maxLength={TITLE_MAX}
+          placeholder="새 할 일 (Enter)"
+          aria-label="할 일 내용"
+          aria-invalid={error ? 'true' : undefined}
+          data-testid="todo-input"
+          className={`flex-1 rounded-md border border-surface-muted bg-surface px-3 py-2 text-sm text-ink placeholder-ink-faint focus:outline-none focus:ring-2 focus:ring-brand-500 ${
+            shake ? 'animate-shake' : ''
+          }`}
+        />
+        <button
+          type="submit"
+          data-testid="todo-add"
+          className="rounded-md bg-brand-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-700"
+        >
+          추가
+        </button>
+      </div>
+      {error ? (
+        <p role="alert" className="text-xs text-red-600" data-testid="todo-input-error">
+          {error}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/src/calendar/TodoList.tsx
+++ b/src/calendar/TodoList.tsx
@@ -1,0 +1,33 @@
+import type { DateKey } from '../domain/types';
+import { useTodos } from '../state/useTodos';
+
+interface TodoListProps {
+  date: DateKey;
+}
+
+export function TodoList({ date }: TodoListProps) {
+  const { listByDate } = useTodos();
+  const items = listByDate(date);
+
+  if (items.length === 0) {
+    return (
+      <p className="text-sm text-ink-faint" data-testid="todo-empty">
+        아직 등록된 할 일이 없어요.
+      </p>
+    );
+  }
+
+  return (
+    <ul aria-label={`${date} 할 일 목록`} className="flex flex-col gap-1" data-testid="todo-list">
+      {items.map((todo) => (
+        <li
+          key={todo.id}
+          data-testid="todo-item"
+          className="rounded-md bg-surface px-3 py-2 text-sm text-ink shadow-sm"
+        >
+          {todo.title}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/state/TodoContext.test.tsx
+++ b/src/state/TodoContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, renderHook, waitFor } from '@testing-library/react';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import type { ReactNode } from 'react';
 import { TodoProvider } from './TodoContext';
@@ -66,6 +66,51 @@ describe('<TodoProvider />', () => {
     const { result } = renderHook(() => useTodos(), { wrapper: wrap(null) });
     await waitFor(() => expect(result.current.state.loaded).toBe(true));
     expect(result.current.listByDate('2026-04-27')).toEqual([]);
+  });
+
+  it('addTodo 는 trim 후 저장하고 영속한다 (#11 ADD)', async () => {
+    const storage = memoryStorage();
+    const { result } = renderHook(() => useTodos(), {
+      wrapper: ({ children }) => (
+        <TodoProvider
+          storage={storage}
+          generateId={() => 'id-1'}
+          now={() => new Date('2026-04-27T09:00:00Z')}
+        >
+          {children}
+        </TodoProvider>
+      ),
+    });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+
+    let res!: ReturnType<typeof result.current.addTodo>;
+    act(() => {
+      res = result.current.addTodo({ date: '2026-04-27', title: '  집중 90분  ' });
+    });
+    expect(res.ok).toBe(true);
+    expect(result.current.listByDate('2026-04-27')).toHaveLength(1);
+    expect(result.current.listByDate('2026-04-27')[0]?.title).toBe('집중 90분');
+
+    // 영속까지 갔는지 확인 — storage 에 직렬화되어 있어야 새로고침 후에도 유지됨
+    const persisted = storage.getItem(STORAGE_KEY);
+    expect(persisted).not.toBeNull();
+    expect(JSON.parse(persisted!).todosByDate['2026-04-27']).toHaveLength(1);
+  });
+
+  it('addTodo 는 빈/공백 입력을 거부한다', async () => {
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(memoryStorage()) });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+    const res = result.current.addTodo({ date: '2026-04-27', title: '   ' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('VALIDATION_EMPTY_TITLE');
+  });
+
+  it('addTodo 는 100자 초과를 거부한다', async () => {
+    const { result } = renderHook(() => useTodos(), { wrapper: wrap(memoryStorage()) });
+    await waitFor(() => expect(result.current.state.loaded).toBe(true));
+    const res = result.current.addTodo({ date: '2026-04-27', title: 'x'.repeat(101) });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error.code).toBe('VALIDATION_TITLE_TOO_LONG');
   });
 
   it('Provider 가 자식 트리를 그대로 렌더링한다', () => {

--- a/src/state/TodoContext.tsx
+++ b/src/state/TodoContext.tsx
@@ -1,25 +1,37 @@
-import { useEffect, useMemo, useReducer, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, type ReactNode } from 'react';
+import type { Result, Todo } from '../domain/types';
 import { TodoRepository, detectBrowserStorage, type StorageLike } from '../infra/TodoRepository';
-import { TodoContext, type TodoContextValue } from './todoContextValue';
+import { TodoContext, type AddTodoInput, type TodoContextValue } from './todoContextValue';
 import {
   initialTodosState,
   selectCountByDate,
   selectListByDate,
   todosReducer,
+  type TodosState,
 } from './todosReducer';
 
 export interface TodoProviderProps {
   children: ReactNode;
   /** 테스트용 저장소 주입. 미지정 시 window.localStorage 자동 감지. */
   storage?: StorageLike | null;
+  /** 테스트용 ID 주입. 미지정 시 crypto.randomUUID. */
+  generateId?: () => string;
+  /** 테스트용 시각 주입. 미지정 시 new Date(). */
+  now?: () => Date;
 }
 
-export function TodoProvider({ children, storage }: TodoProviderProps) {
+const TITLE_MAX = 100;
+
+export function TodoProvider({ children, storage, generateId, now }: TodoProviderProps) {
   const repository = useMemo(
     () => new TodoRepository(storage === undefined ? detectBrowserStorage() : storage),
     [storage],
   );
   const [state, dispatch] = useReducer(todosReducer, initialTodosState);
+
+  // reducer 최신 state 를 effect 외부 콜백에서 안전하게 읽기 위해 ref 동기화.
+  const stateRef = useRef<TodosState>(state);
+  stateRef.current = state;
 
   useEffect(() => {
     const result = repository.load();
@@ -30,13 +42,56 @@ export function TodoProvider({ children, storage }: TodoProviderProps) {
     }
   }, [repository]);
 
+  const addTodo = useCallback(
+    ({ date, title }: AddTodoInput): Result<Todo> => {
+      const trimmed = title.trim();
+      if (trimmed.length === 0) {
+        return { ok: false, error: { code: 'VALIDATION_EMPTY_TITLE', message: '내용을 입력해주세요.' } };
+      }
+      if (trimmed.length > TITLE_MAX) {
+        return {
+          ok: false,
+          error: { code: 'VALIDATION_TITLE_TOO_LONG', message: `최대 ${TITLE_MAX}자까지 입력할 수 있어요.` },
+        };
+      }
+
+      const ts = (now?.() ?? new Date()).toISOString();
+      const todo: Todo = {
+        id: generateId?.() ?? crypto.randomUUID(),
+        date,
+        title: trimmed,
+        done: false,
+        createdAt: ts,
+        updatedAt: ts,
+      };
+
+      // 상태 우선 갱신, 그 다음 영속.
+      const prev = stateRef.current;
+      const list = prev.root.todosByDate[date] ?? [];
+      const nextRoot = {
+        ...prev.root,
+        todosByDate: { ...prev.root.todosByDate, [date]: [...list, todo] },
+      };
+
+      const saved = repository.save(nextRoot);
+      if (!saved.ok) {
+        return saved;
+      }
+
+      dispatch({ type: 'ADD', payload: todo });
+      return { ok: true, data: todo };
+    },
+    [repository, generateId, now],
+  );
+
   const value = useMemo<TodoContextValue>(
     () => ({
       state,
       listByDate: (date) => selectListByDate(state, date),
       countByDate: (date) => selectCountByDate(state, date),
+      addTodo,
     }),
-    [state],
+    [state, addTodo],
   );
 
   return <TodoContext.Provider value={value}>{children}</TodoContext.Provider>;

--- a/src/state/todoContextValue.ts
+++ b/src/state/todoContextValue.ts
@@ -1,11 +1,18 @@
 import { createContext } from 'react';
 import type { DateKey, Todo } from '../domain/types';
+import type { Result } from '../domain/types';
 import type { TodosState } from './todosReducer';
+
+export interface AddTodoInput {
+  date: DateKey;
+  title: string;
+}
 
 export interface TodoContextValue {
   state: TodosState;
   listByDate: (date: DateKey) => Todo[];
   countByDate: (date: DateKey) => number;
+  addTodo: (input: AddTodoInput) => Result<Todo>;
 }
 
 export const TodoContext = createContext<TodoContextValue | null>(null);

--- a/src/state/todosReducer.ts
+++ b/src/state/todosReducer.ts
@@ -6,7 +6,9 @@ export interface TodosState {
   root: PersistRoot;
 }
 
-export type TodosAction = { type: 'LOAD'; payload: PersistRoot };
+export type TodosAction =
+  | { type: 'LOAD'; payload: PersistRoot }
+  | { type: 'ADD'; payload: Todo };
 
 export const initialTodosState: TodosState = {
   loaded: false,
@@ -17,6 +19,17 @@ export function todosReducer(state: TodosState, action: TodosAction): TodosState
   switch (action.type) {
     case 'LOAD':
       return { loaded: true, root: action.payload };
+    case 'ADD': {
+      const { date } = action.payload;
+      const list = state.root.todosByDate[date] ?? [];
+      return {
+        ...state,
+        root: {
+          ...state.root,
+          todosByDate: { ...state.root.todosByDate, [date]: [...list, action.payload] },
+        },
+      };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
## Summary
- 사용자가 핵심 가치(할 일 기록)를 처음 경험하는 슬라이스. 새로고침 후에도 데이터 유지.
- Reducer: ADD 액션. Provider: \`addTodo({date,title})\` — trim + 1~100자 검증 + Repository.save + dispatch. Result 반환.
- 새 컴포넌트: TodoInputForm / TodoList / DayDetailPanel.
- CalendarView 셀 → button + 카운트 배지(#12 의 미완료 카운트로 좁힐 예정).

## AC
- [x] 날짜 클릭 시 패널이 열림
- [x] Enter 로 추가, 입력창 비워지고 포커스 유지
- [x] 100자 초과 차단 (input maxLength + reducer 검증 이중)
- [x] 빈/공백 입력은 차단 + 에러 메시지
- [x] 새로고침 후 유지 — Repository.save 가 dispatch 보다 먼저 실행되어 영속 보장
- [x] 카운트 배지가 셀에 표시

## Test plan
- [x] lint 0 / typecheck 0 / **test 37 passed (6 files)** / build OK
- [ ] PR ci.yml 그린 → 머지 후 deploy-staging + smoke 그린
- [ ] 머지 후 스테이징에서 추가 → 새로고침 → 유지 수동 확인

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)