### PR TITLE
feat(#13): Slice 4 — delete + 5s undo toast

### DIFF
--- a/src/calendar/AddTodoFlow.test.tsx
+++ b/src/calendar/AddTodoFlow.test.tsx
@@ -39,7 +39,7 @@ describe('Add-todo flow (#11)', () => {
       expect(within(panel).getByTestId('todo-list')).toBeInTheDocument();
     });
     expect(within(panel).getAllByTestId('todo-item')).toHaveLength(1);
-    expect(within(panel).getByTestId('todo-item').textContent).toBe('집중 시간 90분');
+    expect(within(panel).getByTestId('todo-title').textContent).toBe('집중 시간 90분');
     expect(input.value).toBe('');
     expect(input).toHaveFocus();
 

--- a/src/calendar/CalendarView.tsx
+++ b/src/calendar/CalendarView.tsx
@@ -4,6 +4,7 @@ import type { DateKey } from '../domain/types';
 import { useTodos } from '../state/useTodos';
 import { buildMonthGrid, type CalendarCell } from './buildMonthGrid';
 import { DayDetailPanel } from './DayDetailPanel';
+import { UndoToast } from './UndoToast';
 
 const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -81,6 +82,7 @@ export function CalendarView({ anchor, today }: CalendarViewProps) {
       </div>
 
       {openDate ? <DayDetailPanel date={openDate} onClose={() => setOpenDate(null)} /> : null}
+      <UndoToast />
     </section>
   );
 }

--- a/src/calendar/RemoveTodoFlow.test.tsx
+++ b/src/calendar/RemoveTodoFlow.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { CalendarView } from './CalendarView';
+import { TodoProvider } from '../state/TodoContext';
+import { STORAGE_KEY, type StorageLike } from '../infra/TodoRepository';
+import type { Todo } from '../domain/types';
+
+function memoryStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+  };
+}
+
+const t = (over: Partial<Todo>): Todo => ({
+  id: over.id ?? 'x',
+  date: over.date ?? '2026-04-27',
+  title: over.title ?? 't',
+  done: over.done ?? false,
+  createdAt: '2026-04-27T00:00:00Z',
+  updatedAt: '2026-04-27T00:00:00Z',
+  ...over,
+});
+
+function seed(items: Todo[]) {
+  return memoryStorage({
+    [STORAGE_KEY]: JSON.stringify({
+      schemaVersion: 1,
+      todosByDate: { '2026-04-27': items },
+    }),
+  });
+}
+
+describe('Remove + undo flow (#13)', () => {
+  it('삭제 즉시 목록에서 사라지고 undo 토스트가 노출된다 (AC-1)', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    render(
+      <TodoProvider storage={seed([t({ id: '1', title: '운동' })])} undoWindowMs={5000}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    await user.click(await screen.findByLabelText(/2026-04-27.*미완료 1개/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    await user.click(within(panel).getByTestId('todo-remove'));
+
+    await waitFor(() => expect(within(panel).queryByTestId('todo-item')).not.toBeInTheDocument());
+    expect(screen.getByTestId('undo-toast')).toBeInTheDocument();
+  });
+
+  it('되돌리기 → 같은 인덱스로 복원 (AC-2)', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    const storage = seed([
+      t({ id: '1', title: '운동' }),
+      t({ id: '2', title: '독서' }),
+      t({ id: '3', title: '글쓰기' }),
+    ]);
+    render(
+      <TodoProvider storage={storage} undoWindowMs={5000}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    await user.click(await screen.findByLabelText(/2026-04-27.*미완료 3개/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    const items = within(panel).getAllByTestId('todo-item');
+    await user.click(within(items[1]!).getByTestId('todo-remove'));
+
+    await waitFor(() => expect(within(panel).getAllByTestId('todo-item')).toHaveLength(2));
+    await user.click(screen.getByTestId('undo-button'));
+
+    await waitFor(() => expect(within(panel).getAllByTestId('todo-item')).toHaveLength(3));
+    const titles = within(panel)
+      .getAllByTestId('todo-item')
+      .map((li) => within(li).getByTestId('todo-title').textContent);
+    expect(titles).toEqual(['운동', '독서', '글쓰기']);
+    const persisted = JSON.parse(storage.getItem(STORAGE_KEY)!);
+    expect(persisted.todosByDate['2026-04-27'].map((x: Todo) => x.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('undo 윈도우 만료 시 토스트가 사라지고 영속이 확정 유지된다 (AC-3)', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+    const storage = seed([t({ id: '1', title: '운동' })]);
+    // 테스트는 짧은 윈도우(50ms)로 같은 동작을 검증한다 — 5초의 의미 동일.
+    render(
+      <TodoProvider storage={storage} undoWindowMs={50}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    await user.click(await screen.findByLabelText(/2026-04-27.*미완료 1개/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    await user.click(within(panel).getByTestId('todo-remove'));
+    expect(screen.getByTestId('undo-toast')).toBeInTheDocument();
+
+    await waitFor(() => expect(screen.queryByTestId('undo-toast')).not.toBeInTheDocument(), {
+      timeout: 1000,
+    });
+
+    const persisted = JSON.parse(storage.getItem(STORAGE_KEY)!);
+    expect(persisted.todosByDate['2026-04-27']).toEqual([]);
+  });
+});

--- a/src/calendar/TodoList.tsx
+++ b/src/calendar/TodoList.tsx
@@ -6,7 +6,7 @@ interface TodoListProps {
 }
 
 export function TodoList({ date }: TodoListProps) {
-  const { listByDate, toggleTodo } = useTodos();
+  const { listByDate, toggleTodo, removeTodo } = useTodos();
   const items = listByDate(date);
 
   if (items.length === 0) {
@@ -20,7 +20,12 @@ export function TodoList({ date }: TodoListProps) {
   return (
     <ul aria-label={`${date} 할 일 목록`} className="flex flex-col gap-1" data-testid="todo-list">
       {items.map((todo) => (
-        <TodoItem key={todo.id} todo={todo} onToggle={() => toggleTodo({ date, id: todo.id })} />
+        <TodoItem
+          key={todo.id}
+          todo={todo}
+          onToggle={() => toggleTodo({ date, id: todo.id })}
+          onRemove={() => removeTodo({ date, id: todo.id })}
+        />
       ))}
     </ul>
   );
@@ -29,9 +34,10 @@ export function TodoList({ date }: TodoListProps) {
 interface TodoItemProps {
   todo: Todo;
   onToggle: () => void;
+  onRemove: () => void;
 }
 
-function TodoItem({ todo, onToggle }: TodoItemProps) {
+function TodoItem({ todo, onToggle, onRemove }: TodoItemProps) {
   return (
     <li
       data-testid="todo-item"
@@ -54,6 +60,15 @@ function TodoItem({ todo, onToggle }: TodoItemProps) {
       >
         {todo.title}
       </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={`${todo.title} 삭제`}
+        data-testid="todo-remove"
+        className="rounded-md px-2 py-1 text-xs text-ink-muted hover:bg-surface-muted hover:text-red-600"
+      >
+        ✕
+      </button>
     </li>
   );
 }

--- a/src/calendar/UndoToast.tsx
+++ b/src/calendar/UndoToast.tsx
@@ -1,0 +1,31 @@
+import { useTodos } from '../state/useTodos';
+
+export function UndoToast() {
+  const { pendingRemoval, undoRemove } = useTodos();
+  if (!pendingRemoval) return null;
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="undo-toast"
+      className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-full bg-ink/90 px-4 py-2 text-sm text-white shadow-card flex items-center gap-3"
+    >
+      <span>
+        “{truncate(pendingRemoval.todo.title, 24)}” 삭제됨
+      </span>
+      <button
+        type="button"
+        onClick={() => undoRemove()}
+        data-testid="undo-button"
+        className="rounded-md bg-white/10 px-3 py-1 text-xs font-semibold hover:bg-white/20"
+      >
+        되돌리기
+      </button>
+    </div>
+  );
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}

--- a/src/state/TodoContext.tsx
+++ b/src/state/TodoContext.tsx
@@ -1,7 +1,20 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, type ReactNode } from 'react';
-import type { Result, Todo } from '../domain/types';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { DateKey, PersistRoot, Result, Todo } from '../domain/types';
 import { TodoRepository, detectBrowserStorage, type StorageLike } from '../infra/TodoRepository';
-import { TodoContext, type AddTodoInput, type TodoContextValue } from './todoContextValue';
+import {
+  TodoContext,
+  type AddTodoInput,
+  type PendingRemoval,
+  type TodoContextValue,
+} from './todoContextValue';
 import {
   initialTodosState,
   selectCountByDate,
@@ -18,11 +31,21 @@ export interface TodoProviderProps {
   generateId?: () => string;
   /** 테스트용 시각 주입. 미지정 시 new Date(). */
   now?: () => Date;
+  /** 5초 undo 토스트의 만료 시간(ms). 테스트에서 짧게 줄일 수 있다. */
+  undoWindowMs?: number;
 }
 
 const TITLE_MAX = 100;
 
-export function TodoProvider({ children, storage, generateId, now }: TodoProviderProps) {
+const DEFAULT_UNDO_MS = 5000;
+
+export function TodoProvider({
+  children,
+  storage,
+  generateId,
+  now,
+  undoWindowMs = DEFAULT_UNDO_MS,
+}: TodoProviderProps) {
   const repository = useMemo(
     () => new TodoRepository(storage === undefined ? detectBrowserStorage() : storage),
     [storage],
@@ -109,6 +132,86 @@ export function TodoProvider({ children, storage, generateId, now }: TodoProvide
     [repository, now],
   );
 
+  const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
+  const expireTimerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (expireTimerRef.current !== null) {
+      window.clearTimeout(expireTimerRef.current);
+      expireTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  const persistRemoval = useCallback(
+    (date: DateKey, id: string): Result<PersistRoot> => {
+      const prev = stateRef.current;
+      const list = prev.root.todosByDate[date] ?? [];
+      const next = list.filter((t) => t.id !== id);
+      const nextRoot: PersistRoot = {
+        ...prev.root,
+        todosByDate: { ...prev.root.todosByDate, [date]: next },
+      };
+      const saved = repository.save(nextRoot);
+      return saved.ok ? { ok: true, data: nextRoot } : saved;
+    },
+    [repository],
+  );
+
+  const removeTodo = useCallback(
+    ({ date, id }: { date: DateKey; id: string }): Result<PendingRemoval> => {
+      const prev = stateRef.current;
+      const list = prev.root.todosByDate[date];
+      if (!list) {
+        return { ok: false, error: { code: 'NOT_FOUND', message: '항목을 찾을 수 없어요.' } };
+      }
+      const index = list.findIndex((t) => t.id === id);
+      if (index < 0) {
+        return { ok: false, error: { code: 'NOT_FOUND', message: '항목을 찾을 수 없어요.' } };
+      }
+      const target = list[index]!;
+
+      const saved = persistRemoval(date, id);
+      if (!saved.ok) return saved;
+
+      dispatch({ type: 'REMOVE', payload: { date, id } });
+
+      const removal: PendingRemoval = { date, todo: target, index };
+      // 이전 대기건이 있다면 즉시 만료(영속은 이미 끝나 있음).
+      clearTimer();
+      setPendingRemoval(removal);
+      expireTimerRef.current = window.setTimeout(() => {
+        setPendingRemoval((cur) => (cur === removal ? null : cur));
+        expireTimerRef.current = null;
+      }, undoWindowMs);
+
+      return { ok: true, data: removal };
+    },
+    [persistRemoval, clearTimer, undoWindowMs],
+  );
+
+  const undoRemove = useCallback((): Result<void> => {
+    const removal = pendingRemoval;
+    if (!removal) {
+      return { ok: false, error: { code: 'NOT_FOUND', message: '되돌릴 항목이 없어요.' } };
+    }
+    const prev = stateRef.current;
+    const list = prev.root.todosByDate[removal.date] ?? [];
+    const idx = Math.max(0, Math.min(removal.index, list.length));
+    const nextList = [...list.slice(0, idx), removal.todo, ...list.slice(idx)];
+    const nextRoot: PersistRoot = {
+      ...prev.root,
+      todosByDate: { ...prev.root.todosByDate, [removal.date]: nextList },
+    };
+    const saved = repository.save(nextRoot);
+    if (!saved.ok) return saved;
+    dispatch({ type: 'RESTORE', payload: { date: removal.date, index: idx, todo: removal.todo } });
+    clearTimer();
+    setPendingRemoval(null);
+    return { ok: true, data: undefined };
+  }, [pendingRemoval, repository, clearTimer]);
+
   const value = useMemo<TodoContextValue>(
     () => ({
       state,
@@ -116,8 +219,11 @@ export function TodoProvider({ children, storage, generateId, now }: TodoProvide
       countByDate: (date) => selectCountByDate(state, date),
       addTodo,
       toggleTodo,
+      removeTodo,
+      undoRemove,
+      pendingRemoval,
     }),
-    [state, addTodo, toggleTodo],
+    [state, addTodo, toggleTodo, removeTodo, undoRemove, pendingRemoval],
   );
 
   return <TodoContext.Provider value={value}>{children}</TodoContext.Provider>;

--- a/src/state/todoContextValue.ts
+++ b/src/state/todoContextValue.ts
@@ -8,12 +8,23 @@ export interface AddTodoInput {
   title: string;
 }
 
+export interface PendingRemoval {
+  date: DateKey;
+  todo: Todo;
+  index: number;
+}
+
 export interface TodoContextValue {
   state: TodosState;
   listByDate: (date: DateKey) => Todo[];
   countByDate: (date: DateKey) => number;
   addTodo: (input: AddTodoInput) => Result<Todo>;
   toggleTodo: (input: { date: DateKey; id: string }) => Result<void>;
+  removeTodo: (input: { date: DateKey; id: string }) => Result<PendingRemoval>;
+  /** 5초 타이머가 만료되기 전이면 마지막 삭제를 같은 인덱스로 복원. */
+  undoRemove: () => Result<void>;
+  /** 현재 진행 중인 5초 undo 대상. 없으면 null. */
+  pendingRemoval: PendingRemoval | null;
 }
 
 export const TodoContext = createContext<TodoContextValue | null>(null);

--- a/src/state/todosReducer.test.ts
+++ b/src/state/todosReducer.test.ts
@@ -69,6 +69,45 @@ describe('todosReducer', () => {
     expect(selectCountByDate(seeded, '2026-04-27')).toBe(2);
   });
 
+  it('REMOVE 는 해당 id 만 제거한다 (#13)', () => {
+    const seeded = todosReducer(initialTodosState, {
+      type: 'LOAD',
+      payload: {
+        schemaVersion: 1,
+        todosByDate: { '2026-04-27': [mk({ id: '1' }), mk({ id: '2' }), mk({ id: '3' })] },
+      },
+    });
+    const next = todosReducer(seeded, { type: 'REMOVE', payload: { date: '2026-04-27', id: '2' } });
+    expect(selectListByDate(next, '2026-04-27').map((t) => t.id)).toEqual(['1', '3']);
+  });
+
+  it('RESTORE 는 같은 인덱스에 다시 끼워넣는다 (#13)', () => {
+    const removed = todosReducer(initialTodosState, {
+      type: 'LOAD',
+      payload: {
+        schemaVersion: 1,
+        todosByDate: { '2026-04-27': [mk({ id: '1' }), mk({ id: '3' })] },
+      },
+    });
+    const next = todosReducer(removed, {
+      type: 'RESTORE',
+      payload: { date: '2026-04-27', index: 1, todo: mk({ id: '2' }) },
+    });
+    expect(selectListByDate(next, '2026-04-27').map((t) => t.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('RESTORE index 가 범위를 벗어나면 가까운 끝으로 클램핑한다', () => {
+    const seeded = todosReducer(initialTodosState, {
+      type: 'LOAD',
+      payload: { schemaVersion: 1, todosByDate: { '2026-04-27': [mk({ id: '1' })] } },
+    });
+    const next = todosReducer(seeded, {
+      type: 'RESTORE',
+      payload: { date: '2026-04-27', index: 999, todo: mk({ id: '2' }) },
+    });
+    expect(selectListByDate(next, '2026-04-27').map((t) => t.id)).toEqual(['1', '2']);
+  });
+
   it('알 수 없는 액션 타입은 state 를 그대로 돌려준다 (방어적)', () => {
     const next = todosReducer(initialTodosState, {
       // 의도적으로 비정상 액션

--- a/src/state/todosReducer.ts
+++ b/src/state/todosReducer.ts
@@ -9,7 +9,9 @@ export interface TodosState {
 export type TodosAction =
   | { type: 'LOAD'; payload: PersistRoot }
   | { type: 'ADD'; payload: Todo }
-  | { type: 'TOGGLE'; payload: { date: DateKey; id: string; updatedAt: string } };
+  | { type: 'TOGGLE'; payload: { date: DateKey; id: string; updatedAt: string } }
+  | { type: 'REMOVE'; payload: { date: DateKey; id: string } }
+  | { type: 'RESTORE'; payload: { date: DateKey; index: number; todo: Todo } };
 
 export const initialTodosState: TodosState = {
   loaded: false,
@@ -36,6 +38,26 @@ export function todosReducer(state: TodosState, action: TodosAction): TodosState
       const list = state.root.todosByDate[date];
       if (!list) return state;
       const next = list.map((t) => (t.id === id ? { ...t, done: !t.done, updatedAt } : t));
+      return {
+        ...state,
+        root: { ...state.root, todosByDate: { ...state.root.todosByDate, [date]: next } },
+      };
+    }
+    case 'REMOVE': {
+      const { date, id } = action.payload;
+      const list = state.root.todosByDate[date];
+      if (!list) return state;
+      const next = list.filter((t) => t.id !== id);
+      return {
+        ...state,
+        root: { ...state.root, todosByDate: { ...state.root.todosByDate, [date]: next } },
+      };
+    }
+    case 'RESTORE': {
+      const { date, index, todo } = action.payload;
+      const list = state.root.todosByDate[date] ?? [];
+      const clamped = Math.max(0, Math.min(index, list.length));
+      const next = [...list.slice(0, clamped), todo, ...list.slice(clamped)];
       return {
         ...state,
         root: { ...state.root, todosByDate: { ...state.root.todosByDate, [date]: next } },


### PR DESCRIPTION
## Summary
- Reducer: REMOVE / RESTORE 액션 (RESTORE 인덱스 클램핑).
- Provider: \`removeTodo\` 영속 후 \`pendingRemoval\` 보관 → 5초 타이머 → 만료 시 자동 정리.
  \`undoRemove\` 가 같은 인덱스에 다시 저장. \`undoWindowMs\` 로 테스트 가속 가능.
- UI: 항목 우측 ✕ 삭제 버튼, 페이지 레벨 \`<UndoToast>\` (role=status).

## AC
- [x] 삭제 즉시 사라짐 + 토스트 노출
- [x] 되돌리기 → 같은 인덱스 복원 + 영속 동기화
- [x] 윈도우 만료 시 토스트 사라지고 영속 삭제 확정
- [x] CI 초록불 + (머지 후) 스테이징 smoke

## Test plan
- [x] reducer 단위 (REMOVE / RESTORE / 클램핑)
- [x] 통합 (3 시나리오)
- [x] lint 0 / typecheck 0 / **test 51 passed (9 files)** / build OK

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)