### PR TITLE
fix(smoke): mobile today-cell selector targets gridcell directly

### DIFF
--- a/tests/smoke/mobile.spec.ts
+++ b/tests/smoke/mobile.spec.ts
@@ -9,11 +9,8 @@ test.describe('mobile sheet smoke (#14)', () => {
     const response = await page.goto(HOME);
     expect(response?.status(), 'home should respond 200').toBe(200);
 
-    // 오늘 셀 클릭 → 패널 노출
-    const todayCell = page
-      .getByRole('gridcell')
-      .filter({ has: page.locator('[aria-current="date"]') })
-      .first();
+    // 오늘 셀 클릭 → 패널 노출. aria-current 가 셀 자신에 붙어있다.
+    const todayCell = page.locator('[role="gridcell"][aria-current="date"]').first();
     await todayCell.click();
 
     const sheet = page.getByTestId('day-detail-sheet');


### PR DESCRIPTION
## Summary
- 모바일 smoke 의 \`filter({ has: '[aria-current=\"date\"]' })\` 가 gridcell 자식만 보고 있어서 매칭이 0 → 30s 타임아웃.
- aria-current 는 gridcell **자신**에 붙어있으므로 평탄한 속성 셀렉터로 변경.

## Why
PR #37 머지 후 main 의 deploy-staging smoke 가 실패한 직접 원인.

## Test plan
- [x] lint / typecheck / vitest 53 passed
- [ ] CI ci.yml 그린 → 머지 후 deploy-staging smoke (chromium + mobile) 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)