### PR TITLE
feat(#15): cross-tab sync + error toast + storage-unavailable banner

### DIFF
--- a/src/calendar/CalendarView.tsx
+++ b/src/calendar/CalendarView.tsx
@@ -5,6 +5,7 @@ import { useTodos } from '../state/useTodos';
 import { buildMonthGrid, type CalendarCell } from './buildMonthGrid';
 import { DayDetailPanel } from './DayDetailPanel';
 import { UndoToast } from './UndoToast';
+import { ErrorToast, StorageUnavailableBanner } from './ErrorToast';
 
 const WEEKDAY_LABELS = ['일', '월', '화', '수', '목', '금', '토'];
 
@@ -31,6 +32,7 @@ export function CalendarView({ anchor, today }: CalendarViewProps) {
       aria-label={`${monthLabel} 달력`}
       className="rounded-card bg-surface shadow-card p-4"
     >
+      <StorageUnavailableBanner />
       <header className="flex items-center justify-between mb-3 gap-2">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">{monthLabel}</h2>
         <nav aria-label="달 이동" className="flex items-center gap-1">
@@ -83,6 +85,7 @@ export function CalendarView({ anchor, today }: CalendarViewProps) {
 
       {openDate ? <DayDetailPanel date={openDate} onClose={() => setOpenDate(null)} /> : null}
       <UndoToast />
+      <ErrorToast />
     </section>
   );
 }

--- a/src/calendar/ErrorToast.tsx
+++ b/src/calendar/ErrorToast.tsx
@@ -1,0 +1,40 @@
+import { useTodos } from '../state/useTodos';
+
+export function ErrorToast() {
+  const { errorMessage, dismissError } = useTodos();
+  if (!errorMessage) return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="error-toast"
+      className="fixed top-4 left-1/2 z-50 -translate-x-1/2 rounded-md bg-red-600 px-4 py-2 text-sm text-white shadow-card flex items-center gap-3"
+    >
+      <span>{errorMessage}</span>
+      <button
+        type="button"
+        onClick={dismissError}
+        aria-label="에러 닫기"
+        data-testid="error-toast-close"
+        className="rounded-md bg-white/10 px-2 py-1 text-xs font-semibold hover:bg-white/20"
+      >
+        닫기
+      </button>
+    </div>
+  );
+}
+
+export function StorageUnavailableBanner() {
+  const { storageUnavailable } = useTodos();
+  if (!storageUnavailable) return null;
+  return (
+    <div
+      role="status"
+      data-testid="storage-unavailable-banner"
+      className="mb-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+    >
+      저장소가 비활성화되어 있어요. 시크릿 모드라면 일반 창에서 다시 열어주세요.
+    </div>
+  );
+}

--- a/src/state/StorageSync.test.tsx
+++ b/src/state/StorageSync.test.tsx
@@ -1,0 +1,126 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { TodoProvider } from './TodoContext';
+import { CalendarView } from '../calendar/CalendarView';
+import { STORAGE_KEY, type StorageLike } from '../infra/TodoRepository';
+import type { Todo } from '../domain/types';
+
+function memStorage(initial: Record<string, string> = {}): StorageLike {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k) => store.get(k) ?? null,
+    setItem: (k, v) => void store.set(k, v),
+    removeItem: (k) => void store.delete(k),
+  };
+}
+
+const mk = (over: Partial<Todo>): Todo => ({
+  id: over.id ?? 'x',
+  date: '2026-04-27',
+  title: over.title ?? 't',
+  done: false,
+  createdAt: '2026-04-27T00:00:00Z',
+  updatedAt: '2026-04-27T00:00:00Z',
+  ...over,
+});
+
+describe('Storage sync + error toast (#15)', () => {
+  it('다른 탭에서 storage 이벤트가 발사되면 LOAD 가 재실행된다 (AC-1)', async () => {
+    const today = new Date(2026, 3, 27);
+    const storage = memStorage();
+
+    render(
+      <TodoProvider storage={storage}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    // 처음에는 미완료 0
+    const cellInit = await screen.findByLabelText(/2026-04-27, 오늘$/);
+    expect(within(cellInit).queryByTestId('todo-count')).not.toBeInTheDocument();
+
+    // 다른 탭이 같은 storage 에 추가했다고 가정 — 직접 setItem 후 storage 이벤트 발사
+    const next = {
+      schemaVersion: 1,
+      todosByDate: { '2026-04-27': [mk({ id: '1', title: '운동' })] },
+    };
+    storage.setItem(STORAGE_KEY, JSON.stringify(next));
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: STORAGE_KEY,
+          newValue: JSON.stringify(next),
+        }),
+      );
+    });
+
+    // 미완료 1 로 갱신
+    await waitFor(() => {
+      expect(screen.getByLabelText(/2026-04-27.*미완료 1개/)).toBeInTheDocument();
+    });
+  });
+
+  it('관계없는 key 의 storage 이벤트는 무시한다', async () => {
+    const today = new Date(2026, 3, 27);
+    const storage = memStorage();
+    render(
+      <TodoProvider storage={storage}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+    await screen.findByLabelText(/2026-04-27, 오늘$/);
+
+    // 다른 키 변화 → 무시되어야 한다
+    storage.setItem('unrelated', 'x');
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: 'unrelated', newValue: 'x' }));
+    });
+    // 여전히 미완료 배지 없음
+    const cell = screen.getByLabelText(/2026-04-27, 오늘$/);
+    expect(within(cell).queryByTestId('todo-count')).not.toBeInTheDocument();
+  });
+
+  it('localStorage 비활성(시크릿 모드) 시 배너가 노출된다 (AC-2)', async () => {
+    const today = new Date(2026, 3, 27);
+    render(
+      <TodoProvider storage={null}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+    expect(await screen.findByTestId('storage-unavailable-banner')).toBeInTheDocument();
+  });
+
+  it('저장 실패 시 친근한 에러 토스트가 노출된다', async () => {
+    const user = userEvent.setup();
+    const today = new Date(2026, 3, 27);
+
+    // setItem 이 항상 QuotaExceeded 를 던지는 storage
+    const failingStorage: StorageLike = {
+      getItem: () => null,
+      setItem: () => {
+        const err = new Error('quota');
+        (err as Error & { name: string }).name = 'QuotaExceededError';
+        throw err;
+      },
+      removeItem: () => undefined,
+    };
+
+    render(
+      <TodoProvider storage={failingStorage}>
+        <CalendarView anchor={today} today={today} />
+      </TodoProvider>,
+    );
+
+    await user.click(await screen.findByLabelText(/2026-04-27, 오늘/));
+    const panel = await screen.findByTestId('day-detail-panel');
+    await user.type(within(panel).getByTestId('todo-input'), '운동{enter}');
+
+    const toast = await screen.findByTestId('error-toast');
+    expect(toast).toHaveTextContent('앗, 저장하지 못했어요. 다시 시도해주세요.');
+
+    await user.click(within(toast).getByTestId('error-toast-close'));
+    await waitFor(() => expect(screen.queryByTestId('error-toast')).not.toBeInTheDocument());
+  });
+});

--- a/src/state/TodoContext.tsx
+++ b/src/state/TodoContext.tsx
@@ -8,7 +8,12 @@ import {
   type ReactNode,
 } from 'react';
 import type { DateKey, PersistRoot, Result, Todo } from '../domain/types';
-import { TodoRepository, detectBrowserStorage, type StorageLike } from '../infra/TodoRepository';
+import {
+  STORAGE_KEY,
+  TodoRepository,
+  detectBrowserStorage,
+  type StorageLike,
+} from '../infra/TodoRepository';
 import {
   TodoContext,
   type AddTodoInput,
@@ -46,17 +51,19 @@ export function TodoProvider({
   now,
   undoWindowMs = DEFAULT_UNDO_MS,
 }: TodoProviderProps) {
-  const repository = useMemo(
-    () => new TodoRepository(storage === undefined ? detectBrowserStorage() : storage),
+  const resolvedStorage = useMemo<StorageLike | null>(
+    () => (storage === undefined ? detectBrowserStorage() : storage),
     [storage],
   );
+  const storageUnavailable = resolvedStorage === null;
+  const repository = useMemo(() => new TodoRepository(resolvedStorage), [resolvedStorage]);
   const [state, dispatch] = useReducer(todosReducer, initialTodosState);
 
   // reducer 최신 state 를 effect 외부 콜백에서 안전하게 읽기 위해 ref 동기화.
   const stateRef = useRef<TodosState>(state);
   stateRef.current = state;
 
-  useEffect(() => {
+  const loadFromRepository = useCallback(() => {
     const result = repository.load();
     if (result.ok) {
       dispatch({ type: 'LOAD', payload: result.data });
@@ -64,6 +71,29 @@ export function TodoProvider({
       dispatch({ type: 'LOAD', payload: { schemaVersion: 1, todosByDate: {} } });
     }
   }, [repository]);
+
+  useEffect(() => {
+    loadFromRepository();
+  }, [loadFromRepository]);
+
+  // 다른 탭/창에서 같은 STORAGE_KEY 가 갱신되면 즉시 LOAD 재실행 → 동기화.
+  // window.localStorage 이외의 주입 storage 에 대해서는 storage 이벤트가 발생하지 않으므로
+  // 이 리스너는 자연스럽게 비활성이며 유닛 테스트는 dispatchEvent 로 검증한다.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== null && e.key !== STORAGE_KEY) return;
+      loadFromRepository();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, [loadFromRepository]);
+
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const dismissError = useCallback(() => setErrorMessage(null), []);
+  const reportSaveError = useCallback((message: string) => {
+    setErrorMessage(message);
+  }, []);
 
   const addTodo = useCallback(
     ({ date, title }: AddTodoInput): Result<Todo> => {
@@ -98,13 +128,14 @@ export function TodoProvider({
 
       const saved = repository.save(nextRoot);
       if (!saved.ok) {
+        reportSaveError('앗, 저장하지 못했어요. 다시 시도해주세요.');
         return saved;
       }
 
       dispatch({ type: 'ADD', payload: todo });
       return { ok: true, data: todo };
     },
-    [repository, generateId, now],
+    [repository, generateId, now, reportSaveError],
   );
 
   const toggleTodo = useCallback(
@@ -125,11 +156,14 @@ export function TodoProvider({
         todosByDate: { ...prev.root.todosByDate, [date]: nextList },
       };
       const saved = repository.save(nextRoot);
-      if (!saved.ok) return saved;
+      if (!saved.ok) {
+        reportSaveError('앗, 저장하지 못했어요. 다시 시도해주세요.');
+        return saved;
+      }
       dispatch({ type: 'TOGGLE', payload: { date, id, updatedAt: ts } });
       return { ok: true, data: undefined };
     },
-    [repository, now],
+    [repository, now, reportSaveError],
   );
 
   const [pendingRemoval, setPendingRemoval] = useState<PendingRemoval | null>(null);
@@ -173,7 +207,10 @@ export function TodoProvider({
       const target = list[index]!;
 
       const saved = persistRemoval(date, id);
-      if (!saved.ok) return saved;
+      if (!saved.ok) {
+        reportSaveError('앗, 저장하지 못했어요. 다시 시도해주세요.');
+        return saved;
+      }
 
       dispatch({ type: 'REMOVE', payload: { date, id } });
 
@@ -188,7 +225,7 @@ export function TodoProvider({
 
       return { ok: true, data: removal };
     },
-    [persistRemoval, clearTimer, undoWindowMs],
+    [persistRemoval, clearTimer, undoWindowMs, reportSaveError],
   );
 
   const undoRemove = useCallback((): Result<void> => {
@@ -205,12 +242,15 @@ export function TodoProvider({
       todosByDate: { ...prev.root.todosByDate, [removal.date]: nextList },
     };
     const saved = repository.save(nextRoot);
-    if (!saved.ok) return saved;
+    if (!saved.ok) {
+      reportSaveError('앗, 되돌리지 못했어요. 다시 시도해주세요.');
+      return saved;
+    }
     dispatch({ type: 'RESTORE', payload: { date: removal.date, index: idx, todo: removal.todo } });
     clearTimer();
     setPendingRemoval(null);
     return { ok: true, data: undefined };
-  }, [pendingRemoval, repository, clearTimer]);
+  }, [pendingRemoval, repository, clearTimer, reportSaveError]);
 
   const value = useMemo<TodoContextValue>(
     () => ({
@@ -222,8 +262,21 @@ export function TodoProvider({
       removeTodo,
       undoRemove,
       pendingRemoval,
+      errorMessage,
+      dismissError,
+      storageUnavailable,
     }),
-    [state, addTodo, toggleTodo, removeTodo, undoRemove, pendingRemoval],
+    [
+      state,
+      addTodo,
+      toggleTodo,
+      removeTodo,
+      undoRemove,
+      pendingRemoval,
+      errorMessage,
+      dismissError,
+      storageUnavailable,
+    ],
   );
 
   return <TodoContext.Provider value={value}>{children}</TodoContext.Provider>;

--- a/src/state/todoContextValue.ts
+++ b/src/state/todoContextValue.ts
@@ -25,6 +25,11 @@ export interface TodoContextValue {
   undoRemove: () => Result<void>;
   /** 현재 진행 중인 5초 undo 대상. 없으면 null. */
   pendingRemoval: PendingRemoval | null;
+  /** 일시적 저장 실패 메시지(쿼터 초과 등). 사용자에게 토스트로 노출. */
+  errorMessage: string | null;
+  dismissError: () => void;
+  /** localStorage 자체 비활성(시크릿 모드 등) 여부. true 면 배너 노출. */
+  storageUnavailable: boolean;
 }
 
 export const TodoContext = createContext<TodoContextValue | null>(null);


### PR DESCRIPTION
## Summary
- TodoProvider 가 \`window.addEventListener('storage', ...)\` 로 STORAGE_KEY 변화를 감지해 LOAD 재실행 → 다른 탭 동기화.
- save 실패 시 친근한 톤의 에러 토스트(\"앗, 저장하지 못했어요. 다시 시도해주세요.\") 노출 + 닫기.
- 시크릿 모드/저장소 비활성 시 영구 배너 노출.

## AC
- [x] 한쪽 탭 추가 → 다른 탭 5초 이내 갱신 (단위 테스트로 storage 이벤트 시뮬)
- [x] 시크릿 모드 시 배너
- [x] CI 초록불

## Test plan
- [x] lint 0 / typecheck 0 / **test 57 passed (11 files)** / build OK
- [ ] PR ci.yml → 머지 후 deploy-staging + smoke

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)